### PR TITLE
Correctness quick wins + docs refresh (safeJson, WAL, main() guard, OTLP provider)

### DIFF
--- a/otlp.js
+++ b/otlp.js
@@ -242,11 +242,13 @@ function transformSpan(span, resourceAttrs, scopeAttrs) {
         }
     }
     
-    // Extract provider
-    const provider = attrs['gen_ai.system'] 
+    // Extract provider. Only use attributes that actually identify the LLM
+    // backend — NOT service.name, which identifies the calling application
+    // (e.g. "my-agent") and was previously masquerading as the provider
+    // whenever instrumentation forgot to emit gen_ai.system.
+    const provider = attrs['gen_ai.system']
         || attrs['gen_ai.provider.name']
         || attrs['llm.vendor']
-        || resourceAttrs['service.name']
         || null;
     
     // Extract service name

--- a/src/db.ts
+++ b/src/db.ts
@@ -15,6 +15,26 @@ if (!fs.existsSync(DATA_DIR)) {
 
 const db = new Database(DB_PATH, { create: true })
 
+// Enable WAL so concurrent writers (OTLP ingest, proxy logging) and readers
+// (dashboard polling, WebSocket fanout) don't serialize through a single
+// rollback journal. busy_timeout gives statements a grace period before
+// surfacing SQLITE_BUSY to the caller.
+db.exec('PRAGMA journal_mode=WAL')
+db.exec('PRAGMA busy_timeout=5000')
+db.exec('PRAGMA synchronous=NORMAL')
+
+// Parse a JSON column that may be NULL, empty, or malformed (e.g. a
+// passthrough body that wasn't actually JSON). Never throws.
+export function safeJson<T>(raw: unknown, fallback: T): T {
+    if (raw == null || raw === '') return fallback
+    if (typeof raw !== 'string') return raw as T
+    try {
+        return JSON.parse(raw) as T
+    } catch {
+        return fallback
+    }
+}
+
 // Helper to add columns if they don't exist (simple migration)
 function ensureColumn(name: string, definition: string) {
     const info = db.query('PRAGMA table_info(traces)').all() as { name: string }[]
@@ -29,7 +49,7 @@ function initSchema() {
             id TEXT PRIMARY KEY,
             timestamp INTEGER NOT NULL,
             duration_ms INTEGER,
-            provider TEXT DEFAULT 'openai',
+            provider TEXT,
             model TEXT,
             prompt_tokens INTEGER DEFAULT 0,
             completion_tokens INTEGER DEFAULT 0,
@@ -663,8 +683,8 @@ export function getLogs({ limit = 50, offset = 0, filters = {} as LogFilters } =
 export function getLogById(id: string) {
     const log = db.query('SELECT * FROM logs WHERE id = $id').get({ $id: id }) as Record<string, unknown> | null
     if (log) {
-        log.attributes = JSON.parse(log.attributes as string || '{}')
-        log.resource_attributes = JSON.parse(log.resource_attributes as string || '{}')
+        log.attributes = safeJson(log.attributes, {})
+        log.resource_attributes = safeJson(log.resource_attributes, {})
     }
     return log
 }
@@ -800,10 +820,10 @@ export function getMetrics({ limit = 50, offset = 0, filters = {} as MetricFilte
 export function getMetricById(id: string) {
     const metric = db.query('SELECT * FROM metrics WHERE id = $id').get({ $id: id }) as Record<string, unknown> | null
     if (metric) {
-        metric.attributes = JSON.parse(metric.attributes as string || '{}')
-        metric.resource_attributes = JSON.parse(metric.resource_attributes as string || '{}')
+        metric.attributes = safeJson(metric.attributes, {})
+        metric.resource_attributes = safeJson(metric.resource_attributes, {})
         if (metric.histogram_data) {
-            metric.histogram_data = JSON.parse(metric.histogram_data as string)
+            metric.histogram_data = safeJson(metric.histogram_data, null)
         }
     }
     return metric

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import * as db from './db'
+import { safeJson } from './db'
 import path from 'path'
 import fs from 'fs'
 import getPort from 'get-port'
@@ -229,7 +230,8 @@ function getMimeType(filePath: string): string {
 }
 
 // Dashboard server
-export const dashboardServer = Bun.serve({
+function startDashboardServer() {
+    return Bun.serve({
     port: DASHBOARD_PORT,
     
     websocket: {
@@ -269,10 +271,11 @@ export const dashboardServer = Bun.serve({
         if (pathname === '/' || pathname === '/index.html') {
             return serveStaticFile('index.html')
         }
-        
+
         return serveStaticFile(pathname)
     }
-})
+    })
+}
 
 // Sanitize analytics data to ensure no null values that break frontend
 function sanitizeByTool(data: unknown[]): unknown[] {
@@ -508,13 +511,13 @@ async function handleApiRoute(req: Request, url: URL): Promise<Response> {
                 request: {
                     method: t.request_method,
                     path: t.request_path,
-                    headers: JSON.parse(t.request_headers as string || '{}'),
-                    body: JSON.parse(t.request_body as string || '{}')
+                    headers: safeJson(t.request_headers, {}),
+                    body: safeJson(t.request_body, {})
                 },
                 response: {
                     status: t.response_status,
-                    headers: JSON.parse(t.response_headers as string || '{}'),
-                    body: JSON.parse(t.response_body as string || '{}')
+                    headers: safeJson(t.response_headers, {}),
+                    body: safeJson(t.response_body, {})
                 }
             })
         }
@@ -532,17 +535,18 @@ async function handleApiRoute(req: Request, url: URL): Promise<Response> {
             const spans = db.getSpansByTraceId(traceId) as Record<string, unknown>[]
             
             // Parse JSON fields and add children array
-            const parsedSpans = spans.map(s => ({
+            type ParsedSpan = Record<string, unknown> & { children: ParsedSpan[] }
+            const parsedSpans: ParsedSpan[] = spans.map(s => ({
                 ...s,
-                request_headers: JSON.parse(s.request_headers as string || '{}'),
-                request_body: JSON.parse(s.request_body as string || '{}'),
-                response_headers: JSON.parse(s.response_headers as string || '{}'),
-                response_body: JSON.parse(s.response_body as string || '{}'),
-                input: JSON.parse(s.input as string || 'null'),
-                output: JSON.parse(s.output as string || 'null'),
-                attributes: JSON.parse(s.attributes as string || '{}'),
-                tags: JSON.parse(s.tags as string || '[]'),
-                children: [] as Record<string, unknown>[]
+                request_headers: safeJson(s.request_headers, {}),
+                request_body: safeJson(s.request_body, {}),
+                response_headers: safeJson(s.response_headers, {}),
+                response_body: safeJson(s.response_body, {}),
+                input: safeJson(s.input, null),
+                output: safeJson(s.output, null),
+                attributes: safeJson(s.attributes, {}),
+                tags: safeJson<unknown[]>(s.tags, []),
+                children: [] as ParsedSpan[]
             }))
             
             // Build tree
@@ -1317,7 +1321,8 @@ async function processPassthroughStreamForLogging(
 }
 
 // Proxy server
-export const proxyServer = Bun.serve({
+function startProxyServer() {
+    return Bun.serve({
     port: PROXY_PORT,
     
     async fetch(req) {
@@ -1396,13 +1401,24 @@ export const proxyServer = Bun.serve({
             headers: corsHeaders
         })
     }
-})
-
-// Initialize OTLP export hooks (forwards traces/logs/metrics to external backends)
-if (EXPORT_ENABLED) {
-    initExportHooks(db)
-    log.info('OTLP export enabled')
+    })
 }
 
-console.log(`[llmflow] Dashboard: http://localhost:${DASHBOARD_PORT}`)
-console.log(`[llmflow] Proxy:     http://localhost:${PROXY_PORT}`)
+// Entry point. Imports of this module from tests or tooling will NOT start
+// listeners — only direct execution (`bun run src/server.ts`) does.
+function main() {
+    if (EXPORT_ENABLED) {
+        initExportHooks(db)
+        log.info('OTLP export enabled')
+    }
+
+    startDashboardServer()
+    startProxyServer()
+
+    console.log(`[llmflow] Dashboard: http://localhost:${DASHBOARD_PORT}`)
+    console.log(`[llmflow] Proxy:     http://localhost:${PROXY_PORT}`)
+}
+
+if (import.meta.main) {
+    main()
+}

--- a/todos.md
+++ b/todos.md
@@ -48,7 +48,95 @@ All critical and medium issues from the v0.3.1 testing have been fixed.
 
 ## Open Issues
 
-_No open issues at this time._
+Findings from a deep inspection of `src/server.ts`, `src/db.ts`, `providers/`,
+`otlp.js`, and the docs surface. Priority is engineering risk × user impact, not
+ticket size.
+
+### P0 — correctness / robustness, ship before any structural work
+
+- [ ] **Wrap every `JSON.parse` on stored rows in a `safeJson` helper.**
+  Sites: `src/server.ts:511-517` (`/api/traces/:id`), `src/server.ts:537-544`
+  (`/api/traces/:id/tree`), `src/db.ts:666-667`, `src/db.ts:803-806`. One
+  malformed `request_body` from a passthrough that wasn't JSON crashes the whole
+  endpoint with a 500. Mechanical fix, ~5-line helper + replace.
+- [ ] **Enable SQLite WAL mode and busy_timeout at boot.** Add
+  `db.exec('PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;')` immediately
+  after `new Database(...)` in `src/db.ts:16`. Concurrent OTLP ingest +
+  WebSocket fanout + dashboard polling will eventually `SQLITE_BUSY` without
+  this.
+- [ ] **Guard top-level `Bun.serve(...)` with `if (import.meta.main)`.**
+  `src/server.ts` starts both listeners at import time, so any test or tool
+  that imports `dashboardServer`/`proxyServer` for typing or wiring boots real
+  ports. Wrap the two `Bun.serve` calls in a `main()` function and call it
+  conditionally.
+- [ ] **Drop the misleading `provider TEXT DEFAULT 'openai'` on `traces`.**
+  Make the column NULLABLE, set OTLP-ingested rows to the resolved provider
+  (`otlp.js:246` already extracts `gen_ai.system` correctly), and render NULL
+  as `unknown` in the UI. Right now Anthropic spans ingested via OTel get
+  silently tagged as OpenAI when the upstream instrumentation forgot to set
+  `gen_ai.system`.
+
+### P1 — performance and correctness at >10k traces
+
+- [ ] **Stream-parse SSE bodies instead of buffering the entire response into a
+      growing string.** `src/server.ts:1023` (`processStreamForLogging`) appends
+  every decoded chunk to `streamBuffer` until `done`. A 1M-token Claude
+  generation holds multi-MB of UTF-16 in memory per concurrent stream. Parse
+  per-line, accumulate the final usage, discard chunks.
+- [ ] **Tag filter is substring-LIKE on serialized JSON** (`src/db.ts:489`).
+  `tag=foo` matches `foobar`, `foo-bar`, etc. Either: (a) a `trace_tags`
+  join table, or (b) `json_each(tags) WHERE value = $tag`.
+- [ ] **`request_body LIKE %q%` does a full table scan on every search.** Add
+  an FTS5 virtual table over `request_body`/`response_body`/`input`/`output`
+  and rewrite the `q` filter to use `MATCH`. bun:sqlite ships FTS5.
+- [ ] **Pruning runs on every insert.** `getTraceCount()` + `DELETE ... WHERE
+      id NOT IN (SELECT ... LIMIT)` is O(N) per write. Either prune every Nth
+  insert, or switch to a timestamp cursor (`DELETE FROM traces WHERE timestamp
+  < ?`) and only when count drifts past a threshold.
+- [ ] **Per-trace body cap.** A 5 MB response body lands verbatim in
+  `response_body`. Truncate with a marker at a configurable cap (mirror Glue's
+  `max_body_bytes`, default 64 KB for headers + 512 KB for bodies). Logged
+  *before* `db.insertTrace`, not after.
+- [ ] **Auth + listening-surface hardening.** Optional `LLMFLOW_TOKEN` bearer
+  enforced on `/api/*`, `/v1/*`, and the WebSocket upgrade. `Dockerfile` and
+  `docker-compose.yml` currently bind to `0.0.0.0` with no auth — one
+  copy-pasted `-p` and the LAN can spam `/v1/traces` until SQLite fills.
+
+### P2 — maintainability, do once the P0s are committed
+
+- [ ] **Port `providers/*.js` to TypeScript.** The CJS `require('../providers')`
+  in `src/server.ts:9` returns `any`, so every method on `Provider`/
+  `PassthroughHandler` is asserted, not typechecked. Real bugs (return-shape
+  drift in `extractUsage` across providers) are hiding behind the casts.
+- [ ] **Replace `ensureColumn` with a real migrations runner.** Add a
+  `schema_version` table and version-stamped migration steps. Current scheme
+  handles ADD COLUMN only — any rename, FTS5 backfill, or index swap will
+  break.
+- [ ] **Graceful shutdown.** SIGINT/SIGTERM handler that closes WebSocket
+  clients, calls `PRAGMA wal_checkpoint(TRUNCATE)`, then `db.close()`.
+- [ ] **Healthcheck port is hardcoded in `Dockerfile`.** Read `$DASHBOARD_PORT`
+  via shell expansion, or freeze the in-container port.
+- [ ] **Pricing data freshness story.** Document in README how `pricing.js`
+  refreshes from LiteLLM, what the fallback path is, and how stale prices
+  affect the headline "see what your LLM calls cost" promise.
+
+### P3 — structural refactors, plan after P0/P1 land
+
+- [ ] **Split `src/server.ts` (1,408 lines).** Suggested layout:
+  `routes/api.ts`, `routes/otlp.ts`, `proxy/handler.ts`,
+  `proxy/streaming.ts`, `health/providers.ts`, `ws/hub.ts`, `static.ts`. The
+  top-level dispatcher becomes ~80 lines.
+- [ ] **WebSocket heartbeat + dead-client reaping.** `wsClients` set grows
+  forever on flaky clients; add ping/pong and drop dead sockets.
+- [ ] **Unit tests for OTLP attribute extraction, pricing edge cases, provider
+      response normalization.** Current tests spawn the whole server — there's
+  no fast inner loop for these modules.
+- [ ] **Document listening surface + auth in README.** Explicit warning for
+  Docker users binding to `0.0.0.0`.
+- [ ] **Port consistency in docs.** Code default is `1337`, `docker-compose`
+  default is `3000`, `README.md` uses `1337`, `website/index.html` and
+  `website/llms.txt` use `3000`. Pick one (`1337` matches the code default)
+  and update everything.
 
 ---
 
@@ -64,4 +152,4 @@ _No open issues at this time._
 
 ---
 
-_Last updated: 2025-12-26 (v0.4.0)_
+_Last updated: 2026-05-20 (post-inspection, pre-v0.5)_

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -251,122 +251,290 @@ LLMFlow recognizes these span types from OpenTelemetry semantic conventions:
 | `embedding` | Embedding generation | Text to vector |
 | `custom` | Custom span | Application-specific |
 
-## Workflow Examples
+## 10 Real-World Scenarios
 
-### Workflow 1: Track OpenAI Costs in Python App
+Each scenario is a copy-pasteable recipe. Default ports: proxy `8080`,
+dashboard + OTLP `3000` (matches `docker-compose.yml` and `website/index.html`;
+`npx llmflow` falls back to `1337` if `DASHBOARD_PORT` is unset and free).
 
-```bash
-# Terminal 1: Start LLMFlow
-npx llmflow
-```
+---
+
+### Scenario 1 — OpenAI Python SDK, zero code change
+
+Drop-in observability for any code already using the official `openai` SDK.
 
 ```python
-# app.py
+# pip install openai
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8080/v1")
+client = OpenAI(base_url="http://localhost:8080/v1")  # was: OpenAI()
 
-# All calls now tracked
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[{"role": "user", "content": "Explain quantum computing"}]
+resp = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "ping"}],
 )
-
-# View at http://localhost:3000
 ```
 
-### Workflow 2: Track LangChain with OpenLLMetry
+Token counts, cost, latency, and full request/response land in
+`http://localhost:3000`. Streaming works the same way.
 
-```bash
-# Terminal 1: Start LLMFlow
-npx llmflow
-```
+---
+
+### Scenario 2 — Anthropic SDK with native API format (passthrough)
+
+The normalized `/anthropic/v1/*` route rewrites responses to OpenAI shape. If
+your code expects native Anthropic JSON (`messages.create` SDK, tool_use
+blocks, etc.), use `/passthrough/anthropic` instead.
 
 ```python
-# langchain_app.py
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from traceloop.sdk import Traceloop
+# pip install anthropic
+import anthropic
 
-# Initialize with LLMFlow as exporter
-Traceloop.init(
-    exporter=OTLPSpanExporter(endpoint="http://localhost:3000/v1/traces")
+client = anthropic.Anthropic(
+    base_url="http://localhost:8080/passthrough/anthropic",
 )
 
-# Now use LangChain normally - traces sent to LLMFlow
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
-
-llm = ChatOpenAI(model="gpt-4o-mini")
-chain = ChatPromptTemplate.from_template("Tell me about {topic}") | llm
-result = chain.invoke({"topic": "Python"})
+msg = client.messages.create(
+    model="claude-sonnet-4-5",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hi"}],
+)
 ```
 
-### Workflow 3: Track Claude Code Usage
+Bytes flow through unchanged; LLMFlow buffers a copy for logging.
+
+---
+
+### Scenario 3 — Vercel AI SDK in a Next.js app
+
+Vercel's `ai` package routes through whatever base URL the underlying provider
+client is given.
+
+```ts
+// app/api/chat/route.ts
+import { createOpenAI } from '@ai-sdk/openai'
+import { streamText } from 'ai'
+
+const llm = createOpenAI({
+  baseURL: 'http://localhost:8080/v1',
+  apiKey: process.env.OPENAI_API_KEY!,
+})
+
+export async function POST(req: Request) {
+  const { messages } = await req.json()
+  const result = streamText({ model: llm('gpt-4o-mini'), messages })
+  return result.toDataStreamResponse()
+}
+```
+
+Streaming chunks reach the browser unmodified; LLMFlow logs the assembled
+response and usage when the stream ends.
+
+---
+
+### Scenario 4 — Glue coding agent (OTLP traces)
+
+Glue emits OTLP/HTTP JSON spans for every LLM call, tool use, and subagent
+turn. Point it at LLMFlow's OTLP endpoint via `~/.glue/config.yaml`:
+
+```yaml
+# ~/.glue/config.yaml
+observability:
+  debug: true
+  redact: true            # scrub API keys / PII before export
+  max_body_bytes: 65536   # truncate large request/response bodies
+  otel:
+    enabled: true
+    endpoint: http://127.0.0.1:3000   # /v1/traces is auto-appended
+    headers: {}
+    service_name: glue
+```
+
+Or via env (overrides YAML):
 
 ```bash
-# Terminal 1: Start LLMFlow
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:3000/v1/traces
+export OTEL_SERVICE_NAME=glue
+glue "refactor the auth middleware"
+```
+
+Each agent turn becomes a root span with child spans for `llm`, `tool`, and
+`subagent` operations — visible in the Timeline tab as a tree.
+
+---
+
+### Scenario 5 — Claude Code CLI (passthrough)
+
+```bash
+# Terminal 1
 npx llmflow
 
-# Terminal 2: Configure and run Claude Code
+# Terminal 2
 export ANTHROPIC_BASE_URL=http://localhost:8080/passthrough/anthropic
 claude
 ```
 
-All Claude Code requests now logged in LLMFlow dashboard.
+Every Claude Code request is logged with native Anthropic format intact, so
+tool calls and thinking blocks render correctly in the trace detail view.
 
-### Workflow 4: Multiple Providers in One App
+---
+
+### Scenario 6 — Codex CLI (OTLP logs)
+
+Codex emits structured OTel logs instead of routing API traffic. Point its
+exporter at the OTLP-logs endpoint:
+
+```toml
+# ~/.codex/config.toml
+[otel]
+endpoint = "http://localhost:3000/v1/logs"
+service_name = "codex"
+```
+
+Codex sessions show up under the Logs tab; correlate with provider API
+traces by `trace_id`.
+
+---
+
+### Scenario 7 — Aider proxy
+
+```bash
+# Terminal 1
+npx llmflow
+
+# Terminal 2
+aider \
+  --openai-api-base http://localhost:8080/v1 \
+  --openai-api-key "$OPENAI_API_KEY" \
+  --model gpt-4o
+```
+
+Aider's diff-applying loop produces one trace per LLM round-trip; useful for
+spotting which file edits drove the most tokens.
+
+---
+
+### Scenario 8 — LangChain + Traceloop (OpenLLMetry)
+
+Traceloop instruments LangChain, LlamaIndex, OpenAI, Anthropic, and others
+with `gen_ai.*` semantic conventions. LLMFlow understands those natively.
+
+```python
+# pip install traceloop-sdk langchain-openai
+from traceloop.sdk import Traceloop
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+
+Traceloop.init(
+    app_name="my-agent",
+    api_endpoint="http://localhost:3000",   # /v1/traces appended internally
+    disable_batch=False,
+)
+
+llm = ChatOpenAI(model="gpt-4o-mini")
+chain = ChatPromptTemplate.from_template("Summarize: {text}") | llm
+chain.invoke({"text": "..."})
+```
+
+Chains, tools, retrievers, and agent runs all show up as nested spans.
+
+---
+
+### Scenario 9 — Mastra agent framework (OTLP)
+
+Mastra's `Telemetry` config drops in any OTLP/HTTP exporter.
+
+```ts
+// mastra.config.ts
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  telemetry: {
+    serviceName: 'mastra-app',
+    enabled: true,
+    export: {
+      type: 'otlp',
+      endpoint: 'http://localhost:3000/v1/traces',
+    },
+  },
+})
+```
+
+Each `agent.generate(...)` call produces a span tree with the agent, tool
+invocations, and underlying LLM requests.
+
+---
+
+### Scenario 10 — Production: Docker + forward to Langfuse/Phoenix
+
+Run LLMFlow as a local sidecar that *also* forwards every span upstream to a
+managed backend, so you keep a queryable local cache and a long-term store.
+
+```yaml
+# docker-compose.yml
+services:
+  llmflow:
+    image: helgesverre/llmflow:latest
+    ports:
+      - "127.0.0.1:8080:8080"   # bind to loopback, not 0.0.0.0
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - ./llmflow-data:/root/.llmflow
+    environment:
+      MAX_TRACES: 100000
+      OTLP_EXPORT_ENDPOINT: https://cloud.langfuse.com/api/public/otel/v1/traces
+      OTLP_EXPORT_HEADERS: "Authorization=Basic ${LANGFUSE_BASIC_AUTH}"
+      OTLP_EXPORT_BATCH_SIZE: 100
+      OTLP_EXPORT_FLUSH_INTERVAL: 5000
+```
+
+Swap the endpoint/headers for Phoenix, Grafana Tempo, Honeycomb, or any other
+OTLP/HTTP backend. Local SQLite stays authoritative for fast search; upstream
+gets the same data on a 5-second flush.
+
+> ⚠ Dashboard and OTLP endpoints currently have no auth. Bind to `127.0.0.1`
+> as above, or front them with a reverse proxy that enforces
+> `Authorization`. See `todos.md` (P1: auth + listening-surface hardening).
+
+---
+
+## Utility Recipes
+
+### Multiple providers in one app
 
 ```python
 from openai import OpenAI
 
-# OpenAI
-openai_client = OpenAI(base_url="http://localhost:8080/v1")
-
-# Anthropic (via OpenAI-compatible endpoint)
-anthropic_client = OpenAI(
-    base_url="http://localhost:8080/anthropic/v1",
-    api_key="your-anthropic-key"
-)
-
-# Ollama (local)
-ollama_client = OpenAI(
-    base_url="http://localhost:8080/ollama/v1",
-    api_key="not-needed"
-)
-
-# All three tracked in same dashboard
+openai_client    = OpenAI(base_url="http://localhost:8080/v1")
+anthropic_client = OpenAI(base_url="http://localhost:8080/anthropic/v1",
+                          api_key="your-anthropic-key")
+ollama_client    = OpenAI(base_url="http://localhost:8080/ollama/v1",
+                          api_key="not-needed")
 ```
 
-### Workflow 5: Export Traces for Analysis
+All three providers are tracked side-by-side in the same dashboard, filterable
+by `provider`.
+
+### Export traces for offline analysis
 
 ```bash
-# Export last 1000 traces as JSON
 curl "http://localhost:3000/api/traces/export?limit=1000" > traces.json
-
-# Export as JSONL
 curl "http://localhost:3000/api/traces/export?format=jsonl" > traces.jsonl
-
-# Export filtered by model
-curl "http://localhost:3000/api/traces/export?model=gpt-4o" > gpt4_traces.json
-
-# Export filtered by date range
-curl "http://localhost:3000/api/traces/export?date_from=1700000000000&date_to=1700100000000" > traces.json
+curl "http://localhost:3000/api/traces/export?model=gpt-4o" > gpt4.json
+curl "http://localhost:3000/api/traces/export?date_from=1700000000000&date_to=1700100000000" > range.json
 ```
 
-### Workflow 6: Check Provider Health
+### Check provider health
 
 ```bash
-# Check if all configured API keys are valid
 curl http://localhost:3000/api/health/providers | jq
-
-# Response:
 # {
 #   "summary": "3/4 providers healthy",
 #   "providers": {
-#     "openai": { "status": "ok", "latency_ms": 245 },
+#     "openai":    { "status": "ok", "latency_ms": 245 },
 #     "anthropic": { "status": "ok", "latency_ms": 312 },
-#     "gemini": { "status": "unconfigured" },
-#     "ollama": { "status": "ok", "latency_ms": 12 }
+#     "gemini":    { "status": "unconfigured" },
+#     "ollama":    { "status": "ok", "latency_ms": 12 }
 #   }
 # }
 ```
@@ -415,15 +583,19 @@ npx llmflow
 
 ## Source Code
 
-- [server.js](https://github.com/HelgeSverre/llmflow/blob/main/server.js): Main proxy and dashboard server
-- [db.js](https://github.com/HelgeSverre/llmflow/blob/main/db.js): SQLite database operations
-- [pricing.js](https://github.com/HelgeSverre/llmflow/blob/main/pricing.js): Cost calculation for 2000+ models
-- [providers/](https://github.com/HelgeSverre/llmflow/tree/main/providers): Provider implementations
-- [otlp.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp.js): OTLP trace ingestion
-- [otlp-logs.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp-logs.js): OTLP log ingestion
-- [otlp-metrics.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp-metrics.js): OTLP metrics ingestion
-- [otlp-export.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp-export.js): Export to external backends
-- [public/](https://github.com/HelgeSverre/llmflow/tree/main/public): Dashboard frontend
+Backend is TypeScript (Bun runtime); providers and OTLP modules are CJS.
+
+- [src/server.ts](https://github.com/HelgeSverre/llmflow/blob/main/src/server.ts): Bun.serve dashboard (port 3000 / 1337) + proxy (port 8080), WebSocket fanout, OTLP ingest dispatch
+- [src/db.ts](https://github.com/HelgeSverre/llmflow/blob/main/src/db.ts): SQLite schema and queries via `bun:sqlite`; tables `traces`, `logs`, `metrics`
+- [pricing.js](https://github.com/HelgeSverre/llmflow/blob/main/pricing.js): Cost calculation for 2000+ models (LiteLLM-backed)
+- [providers/](https://github.com/HelgeSverre/llmflow/tree/main/providers): Per-provider adapters extending `BaseProvider`
+- [providers/passthrough.js](https://github.com/HelgeSverre/llmflow/blob/main/providers/passthrough.js): Native-format passthrough handlers (Anthropic, Gemini, OpenAI, Helicone)
+- [otlp.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp.js): OTLP/HTTP JSON trace ingestion + `gen_ai.*` semantic-convention mapping
+- [otlp-logs.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp-logs.js): OTLP/HTTP log ingestion
+- [otlp-metrics.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp-metrics.js): OTLP/HTTP metrics ingestion
+- [otlp-export.js](https://github.com/HelgeSverre/llmflow/blob/main/otlp-export.js): Forward ingested spans to external OTLP backends (Langfuse, Phoenix, etc.)
+- [logger.js](https://github.com/HelgeSverre/llmflow/blob/main/logger.js): Colored console logger
+- [frontend/](https://github.com/HelgeSverre/llmflow/tree/main/frontend): Svelte 5 SPA, builds to `public/`
 
 ## Distribution
 


### PR DESCRIPTION
## Summary

Two-commit branch landing P0 correctness fixes from a recent inspection plus a
docs refresh. No behavior change on the happy path; each fix closes a
specific failure mode.

### Commit 1 — docs

- **`todos.md`** — replaces the empty *no open issues* section with a
  prioritized P0–P3 backlog (correctness, performance, maintainability,
  structural).
- **`website/llms.txt`** — fixes outdated `server.js`/`db.js` source paths
  (now `src/server.ts` / `src/db.ts`, plus `frontend/`), and replaces the
  6 workflow examples with **10 real-world scenarios** covering OpenAI SDK,
  Anthropic SDK passthrough, Vercel AI SDK, Glue coding agent (OTLP),
  Claude Code, Codex CLI, Aider, LangChain + Traceloop, Mastra, and
  Docker + Langfuse forwarding.

### Commit 2 — correctness quick wins

1. **`safeJson` helper.** Wraps every `JSON.parse` on stored-JSON columns in
   `src/server.ts` (`/api/traces/:id`, `/api/traces/:id/tree`) and `src/db.ts`
   (`getLogById`, `getMetricById`). A malformed `request_body` from a
   non-JSON passthrough used to crash the endpoint with 500 — now falls
   through to the supplied default.
2. **SQLite WAL + busy_timeout=5000 + synchronous=NORMAL** at boot. Without
   WAL, concurrent OTLP ingest + WebSocket fanout + dashboard polling
   serialize through the rollback journal and eventually surface
   `SQLITE_BUSY`.
3. **`if (import.meta.main)` guard** around the two `Bun.serve` calls. The
   server constructions become `startDashboardServer` / `startProxyServer`
   functions called from `main()`. Importing `src/server.ts` from tests or
   tooling no longer boots real listeners on 1337/8080.
4. **OTLP provider attribution** no longer falls back to `service.name`. The
   `gen_ai.system` → `gen_ai.provider.name` → `llm.vendor` chain stays; the
   `service.name` fallback was silently labelling generic OTel apps (Glue,
   Mastra, etc.) as if their own service name were an LLM provider. Schema
   `DEFAULT 'openai'` on `traces.provider` is also dropped — every INSERT
   path binds the column explicitly, so the default was dead-letter clutter
   that lied about column semantics.

## Verification

- `bun run frontend/node_modules/.bin/tsc --noEmit -p src/tsconfig.json` —
  no new errors. The two pre-existing `db.ts` `SQLQueryBindings` errors
  (lines 721, 852) also exist on `main`.
- `bun run test/run-tests.js` — **same baseline as `main`**: 55 passed,
  network-backed provider e2e tests fail identically (they need real API
  keys).
- Manual smoke: `DATA_DIR=… bun run src/server.ts` boots cleanly, `GET
  /api/health` → 200, `POST /v1/traces` → 200, `PRAGMA journal_mode` on the
  resulting DB file returns `wal`.

## Test plan

- [ ] Open dashboard, ingest a few OTLP traces from a Traceloop or
      Glue-instrumented script, confirm `provider` column shows the actual
      LLM backend (or `null` / `unknown`) — not `service.name`.
- [ ] Send a non-JSON passthrough body, confirm `/api/traces/:id` returns
      200 (with empty body fallback) instead of 500.
- [ ] Confirm `~/.llmflow/data.db-wal` and `-shm` files appear after first
      write (WAL mode active).
- [ ] Confirm `bun run src/server.ts` still prints the dashboard/proxy URLs
      and serves both ports.